### PR TITLE
chore: expose the `Error`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub use crate::decode::{
     hex_check_fallback, hex_decode, hex_decode_fallback, hex_decode_unchecked,
 };
 pub use crate::encode::{hex_encode, hex_encode_fallback, hex_string, hex_to};
+pub use crate::error::Error;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", feature = "sse4.1"))]
 pub use crate::decode::hex_check_sse;


### PR DESCRIPTION
Since the `faster_hex::error` module is private, even `faster_hex::error::Error` is public, it still can not be used in other crates.

p.s. bump v0.4.1?