### PR TITLE
Improve performance of fallback implementation

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -208,7 +208,7 @@ unsafe fn hex_decode_avx2(mut src: &[u8], mut dst: &mut [u8]) {
 }
 
 pub fn hex_decode_fallback(src: &[u8], dst: &mut [u8]) {
-    for (slot, bytes) in dst.iter_mut().zip(src.chunks(2)) {
+    for (slot, bytes) in dst.iter_mut().zip(src.chunks_exact(2)) {
         let a = unhex_a(bytes[0] as usize);
         let b = unhex_b(bytes[1] as usize);
         *slot = a | b;

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -95,12 +95,9 @@ pub fn hex_check(src: &[u8]) -> bool {
 }
 
 pub fn hex_check_fallback(src: &[u8]) -> bool {
-    for byte in src {
-        match byte {
-            b'A'..=b'F' | b'a'..=b'f' | b'0'..=b'9' => continue,
-            _ => {
-                return false;
-            }
+    for &byte in src {
+        if UNHEX[byte as usize] == NIL {
+            return false;
         }
     }
     true

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -131,7 +131,7 @@ fn hex(byte: u8) -> u8 {
 }
 
 pub fn hex_encode_fallback(src: &[u8], dst: &mut [u8]) {
-    for (byte, slots) in src.iter().zip(dst.chunks_mut(2)) {
+    for (byte, slots) in src.iter().zip(dst.chunks_exact_mut(2)) {
         slots[0] = hex((*byte >> 4) & 0xf);
         slots[1] = hex(*byte & 0xf);
     }


### PR DESCRIPTION
Before:

```
bench_check_fallback    time:   [174.52 ns 175.79 ns 177.11 ns]

bench_faster_hex_encode_fallback                                                                            
                        time:   [146.59 ns 148.12 ns 149.78 ns]

bench_faster_hex_decode_fallback                                                                            
                        time:   [123.82 ns 125.09 ns 126.55 ns]
```

After:

```
bench_check_fallback    time:   [80.902 ns 81.617 ns 82.401 ns]                                 
                        change: [-54.745% -54.078% -53.337%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_faster_hex_encode_fallback                                                                            
                        time:   [111.62 ns 112.84 ns 113.99 ns]
                        change: [-26.126% -24.597% -23.048%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_faster_hex_decode_fallback                                                                            
                        time:   [108.05 ns 109.04 ns 110.02 ns]
                        change: [-13.733% -12.546% -11.147%] (p = 0.00 < 0.05)
                        Performance has improved.
```