### PR TITLE
return &mut str from encode_hex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,10 @@ mod tests {
     use crate::decode::hex_decode;
     use crate::encode::{hex_encode, hex_string};
     use proptest::proptest;
-    use std::str;
 
     fn _test_hex_encode(s: &String) {
         let mut buffer = vec![0; s.as_bytes().len() * 2];
-        hex_encode(s.as_bytes(), &mut buffer).unwrap();
-        let encode = unsafe { str::from_utf8_unchecked(&buffer[..s.as_bytes().len() * 2]) };
+        let encode = &*hex_encode(s.as_bytes(), &mut buffer).unwrap();
 
         let hex_string = hex_string(s.as_bytes());
 


### PR DESCRIPTION
Add utf8 checks in debug mode, and return `&mut str` from `hex_encode` so the caller can use the hex as str without needing to do the utf8 conversion themselves.