### PR TITLE
Add no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "faster-hex"
 version = "0.6.1"
 authors = ["zhangsoledad <787953403@qq.com>"]
 edition = "2018"
-keywords = ["simd", "hex"]
+keywords = ["simd", "hex", "no-std"]
 license = "MIT"
 description = "Fast hex encoding."
 repository = "https://github.com/NervosFoundation/faster-hex"
@@ -15,6 +15,12 @@ exclude = [
     "fuzz/*",
     "CHANGELOG.md"
 ]
+
+[features]
+default = ["std"]
+std = ["alloc"]
+alloc = []
+
 
 
 [dev-dependencies]

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,14 +1,16 @@
-#![allow(clippy::cast_ptr_alignment)]
-
 #[cfg(target_arch = "x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
+
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec};
 
 use crate::error::Error;
 
 static TABLE: &[u8] = b"0123456789abcdef";
 
+#[cfg(any(feature = "alloc", test))]
 pub fn hex_string(src: &[u8]) -> String {
     let mut buffer = vec![0; src.len() * 2];
     hex_encode(src, &mut buffer)
@@ -22,19 +24,12 @@ pub fn hex_encode(src: &[u8], dst: &mut [u8]) -> Result<(), Error> {
         return Err(Error::InvalidLength(len));
     }
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    {
-        if is_x86_feature_detected!("avx2") {
-            unsafe { hex_encode_avx2(src, dst) };
-            return Ok(());
-        }
-        if is_x86_feature_detected!("sse4.1") {
-            unsafe { hex_encode_sse41(src, dst) };
-            return Ok(());
-        }
+    match crate::vectorization_support() {
+        crate::Vectorization::AVX2 => unsafe { hex_encode_avx2(src, dst) },
+        crate::Vectorization::SSE41 => unsafe { hex_encode_sse41(src, dst) },
+        crate::Vectorization::None => hex_encode_fallback(src, dst),
     }
 
-    hex_encode_fallback(src, dst);
     Ok(())
 }
 
@@ -141,7 +136,7 @@ pub fn hex_encode_fallback(src: &[u8], dst: &mut [u8]) {
 mod tests {
     use crate::encode::hex_encode_fallback;
     use proptest::proptest;
-    use std::str;
+    use core::str;
 
     fn _test_encode_fallback(s: &String) {
         let mut buffer = vec![0; s.as_bytes().len() * 2];

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,8 @@ pub enum Error {
     InvalidLength(usize),
 }
 
-impl ::std::fmt::Debug for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl ::core::fmt::Debug for Error {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         match *self {
             Error::InvalidLength(len) => write!(f, "Invalid input length {}", len),
             Error::InvalidChar => write!(f, "Invalid character"),
@@ -13,12 +13,13 @@ impl ::std::fmt::Debug for Error {
     }
 }
 
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::std::fmt::Debug::fmt(&self, f)
+impl ::core::fmt::Display for Error {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        ::core::fmt::Debug::fmt(&self, f)
     }
 }
 
+#[cfg(feature = "std")]
 impl ::std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,18 @@
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 mod decode;
 mod encode;
 mod error;
 pub use crate::decode::{
     hex_check_fallback, hex_decode, hex_decode_fallback, hex_decode_unchecked,
 };
-pub use crate::encode::{hex_encode, hex_encode_fallback, hex_string};
+pub use crate::encode::{hex_encode, hex_encode_fallback};
+#[cfg(feature = "alloc")]
+pub use crate::encode::hex_string;
+
 pub use crate::error::Error;
 
 #[allow(deprecated)]
@@ -13,12 +21,104 @@ pub use crate::encode::hex_to;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub use crate::decode::hex_check_sse;
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub(crate) enum Vectorization {
+    None = 0,
+    SSE41 = 1,
+    AVX2 = 2,
+}
+
+#[inline(always)]
+pub(crate) fn vectorization_support() -> Vectorization {
+    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        use core::sync::atomic::{AtomicU8, Ordering};
+        static FLAGS: AtomicU8 = AtomicU8::new(u8::MAX);
+
+        // We're OK with relaxed, worst case scenario multiple threads checked the CPUID.
+        let current_flags = FLAGS.load(Ordering::Relaxed);
+        // u8::MAX means uninitialized.
+        if current_flags != u8::MAX {
+            return match current_flags {
+                0 => Vectorization::None,
+                1 => Vectorization::SSE41,
+                2 => Vectorization::AVX2,
+                _ => unreachable!(),
+            };
+        }
+
+        let val = unsafe { vectorization_support_no_cache_x86() };
+
+        FLAGS.store(val as u8, Ordering::Relaxed);
+        return val;
+    }
+    #[allow(unreachable_code)]
+    Vectorization::None
+}
+
+// We enable xsave so it can inline the _xgetbv call.
+#[target_feature(enable = "xsave")]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "sse"))]
+#[cold]
+unsafe fn vectorization_support_no_cache_x86() -> Vectorization {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{__cpuid_count, _xgetbv};
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{__cpuid_count, _xgetbv};
+
+    // SGX doesn't support CPUID,
+    // If there's no SSE there might not be CPUID and there's no SSE4.1/AVX2
+    if cfg!(target_env = "sgx") || !cfg!(target_feature = "sse") {
+        return Vectorization::None;
+    }
+
+    let proc_info_ecx = __cpuid_count(1, 0).ecx;
+    let have_sse4 = (proc_info_ecx >> 19) & 1 == 1;
+    // If there's no SSE4 there can't be AVX2.
+    if !have_sse4 {
+        return Vectorization::None;
+    }
+    let have_xsave = (proc_info_ecx >> 26) & 1 == 1;
+    let have_osxsave = (proc_info_ecx >> 27) & 1 == 1;
+    let have_avx = (proc_info_ecx >> 27) & 1 == 1;
+    if have_xsave && have_osxsave && have_avx {
+        let xcr0 = _xgetbv(0);
+        let os_avx_support = xcr0 & 6 == 6;
+        if os_avx_support {
+            let extended_features_ebx = __cpuid_count(7, 0).ebx;
+            let have_avx2 = (extended_features_ebx >> 5) & 1 == 1;
+            if have_avx2 {
+                return Vectorization::AVX2;
+            }
+        }
+    }
+    Vectorization::SSE41
+}
+
 #[cfg(test)]
 mod tests {
     use crate::decode::hex_decode;
     use crate::encode::{hex_encode, hex_string};
+    use crate::{vectorization_support, Vectorization};
     use proptest::proptest;
     use std::str;
+
+    #[test]
+    fn test_feature_detection() {
+        let vector_support = vectorization_support();
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            match vector_support {
+                Vectorization::AVX2 => assert!(is_x86_feature_detected!("avx2")),
+                Vectorization::SSE41 => assert!(is_x86_feature_detected!("sse4.1")),
+                Vectorization::None => assert!(
+                    !is_x86_feature_detected!("avx2") && !is_x86_feature_detected!("sse4.1")
+                ),
+            }
+        }
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+        assert_eq!(vector_support, Vectorization::None);
+    }
 
     fn _test_hex_encode(s: &String) {
         let mut buffer = vec![0; s.as_bytes().len() * 2];


### PR DESCRIPTION
This makes the crate work in no-std environment by calling `CPUID` instead of using the `is_x86_feature_detected!` macro (the macro is not in core because some of those macros require OS support)