### PR TITLE
Improve encode/decode length check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.61.0
+          toolchain: 1.67.0
           components: rustfmt
           profile: minimal
           override: true
@@ -62,7 +62,7 @@ jobs:
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.61.0
+          toolchain: 1.67.0
           target: ${{ matrix.target }}
           profile: minimal
           override: true

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -88,14 +88,15 @@ unsafe fn nib2byte_avx2(a1: __m256i, b1: __m256i, a2: __m256i, b2: __m256i) -> _
 pub fn hex_check(src: &[u8]) -> bool {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
-        return match crate::vectorization_support() {
+        match crate::vectorization_support() {
             crate::Vectorization::AVX2 | crate::Vectorization::SSE41 => unsafe {
                 hex_check_sse(src)
             },
             crate::Vectorization::None => hex_check_fallback(src),
-        };
+        }
     }
 
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     hex_check_fallback(src)
 }
 
@@ -108,6 +109,8 @@ pub fn hex_check_fallback(src: &[u8]) -> bool {
     true
 }
 
+/// # Safety
+/// Check if a byte slice is valid.
 #[target_feature(enable = "sse4.1")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub unsafe fn hex_check_sse(mut src: &[u8]) -> bool {
@@ -172,13 +175,14 @@ pub fn hex_decode(src: &[u8], dst: &mut [u8]) -> Result<(), Error> {
 pub fn hex_decode_unchecked(src: &[u8], dst: &mut [u8]) {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
-        return match crate::vectorization_support() {
+        match crate::vectorization_support() {
             crate::Vectorization::AVX2 => unsafe { hex_decode_avx2(src, dst) },
             crate::Vectorization::None | crate::Vectorization::SSE41 => {
                 hex_decode_fallback(src, dst)
             }
-        };
+        }
     }
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
     hex_decode_fallback(src, dst);
 }
 
@@ -220,7 +224,7 @@ unsafe fn hex_decode_avx2(mut src: &[u8], mut dst: &mut [u8]) {
         dst = &mut dst[32..];
         src = &src[64..];
     }
-    hex_decode_fallback(&src, &mut dst)
+    hex_decode_fallback(src, dst)
 }
 
 pub fn hex_decode_fallback(src: &[u8], dst: &mut [u8]) {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -145,13 +145,22 @@ pub unsafe fn hex_check_sse(mut src: &[u8]) -> bool {
     hex_check_fallback(src)
 }
 
+/// Hex decode src into dst.
+/// The length of src must be even and not zero.
+/// The length of dst must be at least src.len() / 2.
 pub fn hex_decode(src: &[u8], dst: &mut [u8]) -> Result<(), Error> {
     if src.is_empty() {
         return Err(Error::InvalidLength(0));
     }
-    let len = dst.len().checked_mul(2).unwrap();
-    if src.len() < len || ((src.len() & 1) != 0) {
-        return Err(Error::InvalidLength(len));
+
+    if src.len() & 1 != 0 {
+        return Err(Error::InvalidLength(src.len()));
+    }
+
+    let expect_dst_len = src.len().checked_div(2).unwrap();
+
+    if dst.len() < expect_dst_len {
+        return Err(Error::InvalidLength(dst.len()));
     }
     if !hex_check(src) {
         return Err(Error::InvalidChar);

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -23,6 +23,8 @@ pub fn hex_string(src: &[u8]) -> String {
     }
 }
 
+/// Hex encode src into dst.
+/// The length of dst must be at least src.len() * 2.
 pub fn hex_encode<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a mut str, Error> {
     unsafe fn mut_str(buffer: &mut [u8]) -> &mut str {
         if cfg!(debug_assertions) {
@@ -32,9 +34,12 @@ pub fn hex_encode<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a mut str, Erro
         }
     }
 
-    let len = src.len().checked_mul(2).unwrap();
-    if dst.len() < len {
-        return Err(Error::InvalidLength(len));
+    let expect_dst_len = src
+        .len()
+        .checked_mul(2)
+        .ok_or(Error::InvalidLength(src.len()))?;
+    if dst.len() < expect_dst_len {
+        return Err(Error::InvalidLength(expect_dst_len));
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -53,9 +53,12 @@ pub fn hex_encode<'a>(src: &[u8], dst: &'a mut [u8]) -> Result<&'a mut str, Erro
         return Ok(unsafe { mut_str(dst) });
     }
 
-    hex_encode_fallback(src, dst);
-    // Saftey: We just wrote valid utf8 hex string into the dst
-    Ok(unsafe { mut_str(dst) })
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        hex_encode_fallback(src, dst);
+        // Safety: We just wrote valid utf8 hex string into the dst
+        Ok(unsafe { mut_str(dst) })
+    }
 }
 
 #[deprecated(since = "0.3.0", note = "please use `hex_encode` instead")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ pub enum Error {
 impl ::core::fmt::Debug for Error {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         match *self {
-            Error::InvalidLength(len) => write!(f, "Invalid input length {}", len),
+            Error::InvalidLength(len) => write!(f, "Invalid input length {len}"),
             Error::InvalidChar => write!(f, "Invalid character"),
         }
     }


### PR DESCRIPTION
This PR improved `src/dst`'s length check of `hex_encode/hex_decode`, upgrade cargo toolchain from 1.61 to 1.67, and fix cargo clippy error.  

CC. @zhangsoledad 