### PR TITLE
fix: unblock vectorization* without SSE

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,10 +71,7 @@ pub(crate) fn vectorization_support() -> Vectorization {
 
 // We enable xsave so it can inline the _xgetbv call.
 #[target_feature(enable = "xsave")]
-#[cfg(all(
-    any(target_arch = "x86", target_arch = "x86_64"),
-    target_feature = "sse"
-))]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[cold]
 unsafe fn vectorization_support_no_cache_x86() -> Vectorization {
     #[cfg(target_arch = "x86")]
@@ -127,6 +124,7 @@ mod tests {
                 Vectorization::AVX2 => assert!(is_x86_feature_detected!("avx2")),
                 Vectorization::SSE41 => assert!(is_x86_feature_detected!("sse4.1")),
                 Vectorization::None => assert!(
+                    !cfg!(target_feature = "sse") ||
                     !is_x86_feature_detected!("avx2") && !is_x86_feature_detected!("sse4.1")
                 ),
             }


### PR DESCRIPTION
Fixes #32. No need to compile out the code due to 
https://github.com/nervosnetwork/faster-hex/blob/635076e795b7a546942b89d736457c93e911770f/src/lib.rs#L85-L89

```
$ rustc -vV
rustc 1.71.0 (7bb61853a 2023-07-10) (built from a source tarball)
binary: rustc
commit-hash: 7bb61853ad519abd3e5b3edfddc1cf00b1d4437d
commit-date: 2023-07-10
host: i686-unknown-freebsd
release: 1.71.0
LLVM version: 16.0.5

$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.04s
     Running unittests src/lib.rs (target/debug/deps/faster_hex-01f78b18e3f1e846)

running 18 tests
test decode::test_sse::test_decode_zero_length_src_should_be_ok ... ok
test decode::tests::test_init_static_array_is_right ... ok
test encode::tests::test_encode_zero_length_src_should_be_ok ... ok
test serde::tests::test_serde_default ... ok
test decode::tests::test_decode_fallback ... ok
test encode::tests::test_encode_fallback ... ok
test tests::test_feature_detection ... ok
test serde::tests::test_serde_deserialize ... ok
test decode::tests::test_check_fallback_true ... ok
test serde::tests::test_serde ... ok
test decode::tests::test_check_fallback_false ... ok
test decode::test_sse::test_check_sse_false ... ok
test serde::tests::test_simple ... ok
test tests::test_hex_decode ... ok
test decode::test_sse::test_check_sse_true ... ok
test tests::test_hex_decode_check_odd ... ok
test tests::test_hex_encode ... ok
test tests::test_hex_decode_check ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s

   Doc-tests faster-hex

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
