### PR TITLE
src/lib.rs: make conditionals for x86 vectorization more similar.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,10 @@ pub(crate) enum Vectorization {
 
 #[inline(always)]
 pub(crate) fn vectorization_support() -> Vectorization {
-    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(
+              any(target_arch = "x86", target_arch = "x86_64"),
+              target_feature = "sse"
+))]
     {
         use core::sync::atomic::{AtomicU8, Ordering};
         static FLAGS: AtomicU8 = AtomicU8::new(u8::MAX);


### PR DESCRIPTION
If, for some reason, your i386 rust doesn't support the "sse" target feature (perhaps built for i586), you end up with use but no definition for vectorization_support_no_cache_x86(). This change fixes that.