### PR TITLE
fix: fix deserializing owned hex string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 ]
 
 [dependencies]
-serde = { version = "1.0", optional = true, features = ["derive"]}
+serde = { version = "1.0", optional = true }
 
 [features]
 default = ["std", "serde"]


### PR DESCRIPTION
* Fix deserializing owned hex string

  We should first deserialize to `Cow<str>`, or it won't work with a escaped string or crates that don't support deserializing borrowed `[u8]`/`str` (e.g. toml, https://github.com/axonweb3/axon/pull/1396).

* Don't depend on serde derive, and don't export faster_hex_serde_macros

  These are some minor clean-ups. If you don't like them I can remove them.