### PR TITLE
Install  `rust-toolchain` `v1.73` on CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.67.0
+          toolchain: stable
           components: rustfmt
           profile: minimal
           override: true
@@ -62,7 +62,7 @@ jobs:
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.67.0
+          toolchain: stable
           target: ${{ matrix.target }}
           profile: minimal
           override: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.73
           components: rustfmt
           profile: minimal
           override: true
@@ -62,7 +62,7 @@ jobs:
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.73
           target: ${{ matrix.target }}
           profile: minimal
           override: true


### PR DESCRIPTION
This PR want to fix the CI error: "error: failed to extract package (perhaps you ran out of disk space?): No space left on device (os error 28)"


```
/home/runner/.cargo/bin/rustup show
Default host: x86_64-unknown-linux-gnu
rustup home:  /home/runner/.rustup

stable-x86_64-unknown-linux-gnu (default)
rustc 1.73.0 (cc66ad468 2023-10-03)
/home/runner/.cargo/bin/rustup -V
rustup 1.26.0 (5af9b9484 2023-04-05)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.73.0 (cc66ad468 2023-10-03)`
Installed rustup 1.26.0 support profiles
/home/runner/.cargo/bin/rustup set profile minimal
info: profile set to 'minimal'
/home/runner/.cargo/bin/rustup toolchain install 1.67.0
info: syncing channel updates for '1.67.0-x86_64-unknown-linux-gnu'
info: latest update on 2023-01-26, rust version 1.67.0 (fc594f156 2023-01-24)
info: downloading component 'cargo'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: installing component 'cargo'
info: installing component 'rust-std'
info: installing component 'rustc'
info: rolling back changes
error: failed to extract package (perhaps you ran out of disk space?): No space left on device (os error 28)
Error: The process '/home/runner/.cargo/bin/rustup' failed with exit code 1

```