### PR TITLE
Yanked `v0.8.2`, re-create `v0.9.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# [0.8.2](https://github.com/nervosnetwork/faster-hex/compare/v0.8.1...v0.8.2) (2023-11-19)
+# [0.9.0](https://github.com/nervosnetwork/faster-hex/compare/v0.9.0..v0.8.2) (2023-11-22)
+Re create `v0.9.0`, since `v0.8.2` introduced a [break change](https://github.com/nervosnetwork/faster-hex/issues/43#issuecomment-1822551961), 
+
+# Yanked: [0.8.2](https://github.com/nervosnetwork/faster-hex/compare/v0.8.1...v0.8.2) (2023-11-19)
 
 ### Bug Fixes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faster-hex"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["zhangsoledad <787953403@qq.com>"]
 edition = "2018"
 keywords = ["simd", "hex", "no-std"]


### PR DESCRIPTION
Yank v0.8.2, since it introduced a break change.
Ref: https://github.com/nervosnetwork/faster-hex/issues/43