### PR TITLE
Upgrade dev-dependency criterion to 0.4, bump faster-hex to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faster-hex"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["zhangsoledad <787953403@qq.com>"]
 edition = "2018"
 keywords = ["simd", "hex", "no-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = ["dep:serde", "alloc"]
 heapless = { version = "0.8" }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 rustc-hex = "1.0"
 hex = "0.3.2"
 proptest = "1.0"


### PR DESCRIPTION
- bump faster-hex to 0.10.0
- Upgrade criterion to 0.4 to fix:
```bash

❯ cargo deny check --hide-inclusion-graph --show-stats advisories sources
2024-09-14 05:10:37 [WARN] unable to find a config path, falling back to default config
error[unsound]: Potential unaligned read
  ┌─ /home/exec/Projects/github.com/nervosnetwork/faster-hex/Cargo.lock:1:1
  │
1 │ atty 0.2.14 registry+https://github.com/rust-lang/crates.io-index
  │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
  │
  ├ ID: RUSTSEC-2021-0145
  ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0145
  ├ On windows, `atty` dereferences a potentially unaligned pointer.

    In practice however, the pointer won't be unaligned unless a custom global allocator is used.

    In particular, the `System` allocator on windows uses `HeapAlloc`, which guarantees a large enough alignment.

    # atty is Unmaintained

    A Pull Request with a fix has been provided over a year ago but the maintainer seems to be unreachable.

    Last release of `atty` was almost 3 years ago.

    ## Possible Alternative(s)

    The below list has not been vetted in any way and may or may not contain alternatives;

     - [std::io::IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) - Stable since Rust 1.70.0
     - [is-terminal](https://crates.io/crates/is-terminal) - Standalone crate supporting Rust older than 1.70.0
  ├ Announcement: https://github.com/softprops/atty/issues/50
  ├ Solution: No safe upgrade is available!

error[unmaintained]: serde_cbor is unmaintained
   ┌─ /home/exec/Projects/github.com/nervosnetwork/faster-hex/Cargo.lock:66:1
   │
66 │ serde_cbor 0.11.2 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2021-0127
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0127
   ├ The `serde_cbor` crate is unmaintained. The author has archived the github repository.

     Alternatives proposed by the author:

      * [`ciborium`](https://crates.io/crates/ciborium)
      * [`minicbor`](https://crates.io/crates/minicbor)
   ├ Announcement: https://github.com/pyfisch/cbor
   ├ Solution: No safe upgrade is available!

 advisories FAILED: 2 errors, 0 warnings, 0 notes
        sources ok: 0 errors, 0 warnings, 0 notes

```
