### PR TITLE
Check bit 28 for AVX support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ fn vectorization_support_no_cache_x86() -> Vectorization {
 
     let have_xsave = (proc_info_ecx >> 26) & 1 == 1;
     let have_osxsave = (proc_info_ecx >> 27) & 1 == 1;
-    let have_avx = (proc_info_ecx >> 27) & 1 == 1;
+    let have_avx = (proc_info_ecx >> 28) & 1 == 1;
     if have_xsave && have_osxsave && have_avx {
         // # Safety: We checked that the processor supports xsave
         if unsafe { avx2_support_no_cache_x86() } {


### PR DESCRIPTION
When checking for AVX support on x86 platforms, the code currently looks at bit 27 twice:

https://github.com/nervosnetwork/faster-hex/blob/a7ce51feb378bc713f7e39f2f3c3172372abc4ec/src/lib.rs#L95-L97

Wikipedia's [CPUID article](https://en.wikipedia.org/wiki/CPUID#EAX=1:_Processor_Info_and_Feature_Bits) states that the `avx` flag is in bit 28. This pull request changes the code to check bit 28 for AVX support instead of bit 27.

I ensured that all tests passed before committing.