### PR TITLE
Add NEON encode and check

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,5 +1,7 @@
 // avx2 decode modified from https://github.com/zbjornson/fast-hex/blob/master/src/hex.cc
 
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::*;
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
@@ -114,7 +116,16 @@ pub fn hex_check_with_case(src: &[u8], check_case: CheckCase) -> bool {
         }
     }
 
-    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(target_arch = "aarch64")]
+    {
+        match crate::vectorization_support() {
+            crate::Vectorization::Neon => unsafe { hex_check_neon_with_case(src, check_case) },
+            crate::Vectorization::None => hex_check_fallback_with_case(src, check_case),
+            _ => unreachable!(),
+        }
+    }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
     hex_check_fallback_with_case(src, check_case)
 }
 
@@ -210,6 +221,72 @@ pub unsafe fn hex_check_sse_with_case(mut src: &[u8], check_case: CheckCase) -> 
     hex_check_fallback_with_case(src, check_case)
 }
 
+#[target_feature(enable = "neon")]
+#[cfg(target_arch = "aarch64")]
+pub unsafe fn hex_check_neon(src: &[u8]) -> bool {
+    hex_check_neon_with_case(src, CheckCase::None)
+}
+
+#[target_feature(enable = "neon")]
+#[cfg(target_arch = "aarch64")]
+pub unsafe fn hex_check_neon_with_case(mut src: &[u8], check_case: CheckCase) -> bool {
+    let ascii_zero = vdupq_n_u8(b'0' - 1);
+    let ascii_nine = vdupq_n_u8(b'9' + 1);
+    let ascii_ua = vdupq_n_u8(b'A' - 1);
+    let ascii_uf = vdupq_n_u8(b'F' + 1);
+    let ascii_la = vdupq_n_u8(b'a' - 1);
+    let ascii_lf = vdupq_n_u8(b'f' + 1);
+
+    while src.len() >= 16 {
+        let unchecked = vld1q_u8(src.as_ptr() as *const _);
+
+        let gt0 = vcgtq_u8(unchecked, ascii_zero);
+        let lt9 = vcltq_u8(unchecked, ascii_nine);
+        let valid_digit = vandq_u8(gt0, lt9);
+
+        let (valid_la_lf, valid_ua_uf) = match check_case {
+            CheckCase::None => {
+                let gtua = vcgtq_u8(unchecked, ascii_ua);
+                let ltuf = vcltq_u8(unchecked, ascii_uf);
+
+                let gtla = vcgtq_u8(unchecked, ascii_la);
+                let ltlf = vcltq_u8(unchecked, ascii_lf);
+
+                (Some(vandq_u8(gtla, ltlf)), Some(vandq_u8(gtua, ltuf)))
+            }
+            CheckCase::Lower => {
+                let gtla = vcgtq_u8(unchecked, ascii_la);
+                let ltlf = vcltq_u8(unchecked, ascii_lf);
+
+                (Some(vandq_u8(gtla, ltlf)), None)
+            }
+            CheckCase::Upper => {
+                let gtua = vcgtq_u8(unchecked, ascii_ua);
+                let ltuf = vcltq_u8(unchecked, ascii_uf);
+
+                (None, Some(vandq_u8(gtua, ltuf)))
+            }
+        };
+
+        let valid_letter = match (valid_la_lf, valid_ua_uf) {
+            (Some(valid_lower), Some(valid_upper)) => vorrq_u8(valid_lower, valid_upper),
+            (Some(valid_lower), None) => valid_lower,
+            (None, Some(valid_upper)) => valid_upper,
+            _ => unreachable!(),
+        };
+
+        let ret = vminvq_u8(vorrq_u8(valid_digit, valid_letter));
+
+        if ret == 0 {
+            return false;
+        }
+
+        src = &src[16..];
+    }
+
+    hex_check_fallback_with_case(src, check_case)
+}
+
 /// Hex decode src into dst.
 /// The length of src must be even, and it's allowed to decode a zero length src.
 /// The length of dst must be at least src.len() / 2.
@@ -247,7 +324,7 @@ pub fn hex_decode_unchecked(src: &[u8], dst: &mut [u8]) {
             crate::Vectorization::AVX2 => unsafe { hex_decode_avx2(src, dst) },
             crate::Vectorization::None | crate::Vectorization::SSE41 => {
                 hex_decode_fallback(src, dst)
-            },
+            }
             _ => unreachable!(),
         }
     }
@@ -455,15 +532,25 @@ mod tests {
     }
 }
 
-#[cfg(all(test, any(target_arch = "x86", target_arch = "x86_64")))]
-mod test_sse {
+#[cfg(all(
+    test,
+    any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")
+))]
+mod test_simd {
     use crate::decode::{
-        hex_check, hex_check_fallback, hex_check_fallback_with_case, hex_check_sse,
-        hex_check_sse_with_case, hex_check_with_case, hex_decode, hex_decode_unchecked,
-        hex_decode_with_case, CheckCase,
+        hex_check, hex_check_fallback, hex_check_fallback_with_case, hex_check_with_case,
+        hex_decode, hex_decode_unchecked, hex_decode_with_case, CheckCase,
     };
+    #[cfg(target_arch = "aarch64")]
+    use crate::decode::{hex_check_neon, hex_check_neon_with_case};
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    use crate::decode::{hex_check_sse, hex_check_sse_with_case};
+    #[cfg(target_arch = "aarch64")]
+    use std::arch::is_aarch64_feature_detected;
+
     use proptest::proptest;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn _test_check_sse_with_case(s: &String, check_case: CheckCase, expect_result: bool) {
         if is_x86_feature_detected!("sse4.1") {
             assert_eq!(
@@ -473,12 +560,14 @@ mod test_sse {
         }
     }
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn _test_check_sse_true(s: &String) {
         if is_x86_feature_detected!("sse4.1") {
             assert!(unsafe { hex_check_sse(s.as_bytes()) });
         }
     }
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     proptest! {
     #[test]
     fn test_check_sse_true(ref s in "([0-9a-fA-F][0-9a-fA-F])+") {
@@ -505,12 +594,13 @@ mod test_sse {
         }
     }
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn _test_check_sse_false(s: &String) {
         if is_x86_feature_detected!("sse4.1") {
             assert!(!unsafe { hex_check_sse(s.as_bytes()) });
         }
     }
-
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     proptest! {
         #[test]
         fn test_check_sse_false(ref s in ".{16}[^0-9a-fA-F]+") {
@@ -518,6 +608,67 @@ mod test_sse {
             _test_check_sse_with_case(s, CheckCase::None, false);
             _test_check_sse_with_case(s, CheckCase::Lower, false);
             _test_check_sse_with_case(s, CheckCase::Upper, false);
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn _test_check_neon_with_case(s: &String, check_case: CheckCase, expect_result: bool) {
+        if is_aarch64_feature_detected!("neon") {
+            assert_eq!(
+                unsafe { hex_check_neon_with_case(s.as_bytes(), check_case) },
+                expect_result
+            )
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn _test_check_neon_true(s: &String) {
+        if is_aarch64_feature_detected!("neon") {
+            assert!(unsafe { hex_check_neon(s.as_bytes()) });
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    proptest! {
+    #[test]
+    fn test_check_neon_true(ref s in "([0-9a-fA-F][0-9a-fA-F])+") {
+            _test_check_neon_true(s);
+            _test_check_neon_with_case(s, CheckCase::None, true);
+            match (s.contains(char::is_lowercase), s.contains(char::is_uppercase)){
+                (true, true) => {
+                    _test_check_neon_with_case(s, CheckCase::Lower, false);
+                    _test_check_neon_with_case(s, CheckCase::Upper, false);
+                },
+                (true, false) => {
+                    _test_check_neon_with_case(s, CheckCase::Lower, true);
+                    _test_check_neon_with_case(s, CheckCase::Upper, false);
+                },
+                (false, true) => {
+                    _test_check_neon_with_case(s, CheckCase::Lower, false);
+                    _test_check_neon_with_case(s, CheckCase::Upper, true);
+                },
+                (false, false) => {
+                    _test_check_neon_with_case(s, CheckCase::Lower, true);
+                    _test_check_neon_with_case(s, CheckCase::Upper, true);
+                }
+            }
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn _test_check_neon_false(s: &String) {
+        if is_aarch64_feature_detected!("neon") {
+            assert!(!unsafe { hex_check_neon(s.as_bytes()) });
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    proptest! {
+        #[test]
+        fn test_check_neon_false(ref s in ".{16}[^0-9a-fA-F]+") {
+            _test_check_neon_false(s);
+            _test_check_neon_with_case(s, CheckCase::None, false);
+            _test_check_neon_with_case(s, CheckCase::Lower, false);
+            _test_check_neon_with_case(s, CheckCase::Upper, false);
         }
     }
 
@@ -536,9 +687,16 @@ mod test_sse {
         assert!(hex_check_fallback(src));
         assert!(hex_check_fallback_with_case(src, CheckCase::None));
 
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         if is_x86_feature_detected!("sse4.1") {
             assert!(unsafe { hex_check_sse_with_case(src, CheckCase::None) });
             assert!(unsafe { hex_check_sse(src) });
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        if is_aarch64_feature_detected!("neon") {
+            assert!(unsafe { hex_check_neon_with_case(src, CheckCase::None) });
+            assert!(unsafe { hex_check_neon(src) });
         }
 
         // this function have no return value, so we just execute it and expect no panic

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -120,7 +120,6 @@ pub fn hex_check_with_case(src: &[u8], check_case: CheckCase) -> bool {
         match crate::vectorization_support() {
             crate::Vectorization::Neon => unsafe { hex_check_neon_with_case(src, check_case) },
             crate::Vectorization::None => hex_check_fallback_with_case(src, check_case),
-            _ => unreachable!(),
         }
     }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -112,7 +112,6 @@ pub fn hex_check_with_case(src: &[u8], check_case: CheckCase) -> bool {
                 hex_check_sse_with_case(src, check_case)
             },
             crate::Vectorization::None => hex_check_fallback_with_case(src, check_case),
-            _ => unreachable!(),
         }
     }
 
@@ -326,7 +325,6 @@ pub fn hex_decode_unchecked(src: &[u8], dst: &mut [u8]) {
             crate::Vectorization::None | crate::Vectorization::SSE41 => {
                 hex_decode_fallback(src, dst)
             }
-            _ => unreachable!(),
         }
     }
     #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -110,6 +110,7 @@ pub fn hex_check_with_case(src: &[u8], check_case: CheckCase) -> bool {
                 hex_check_sse_with_case(src, check_case)
             },
             crate::Vectorization::None => hex_check_fallback_with_case(src, check_case),
+            _ => unreachable!(),
         }
     }
 
@@ -246,7 +247,8 @@ pub fn hex_decode_unchecked(src: &[u8], dst: &mut [u8]) {
             crate::Vectorization::AVX2 => unsafe { hex_decode_avx2(src, dst) },
             crate::Vectorization::None | crate::Vectorization::SSE41 => {
                 hex_decode_fallback(src, dst)
-            }
+            },
+            _ => unreachable!(),
         }
     }
     #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -101,7 +101,6 @@ pub fn hex_encode_custom<'a>(
             crate::Vectorization::AVX2 => unsafe { hex_encode_avx2(src, dst, upper_case) },
             crate::Vectorization::SSE41 => unsafe { hex_encode_sse41(src, dst, upper_case) },
             crate::Vectorization::None => hex_encode_custom_case_fallback(src, dst, upper_case),
-            _ => unreachable!(),
         }
         // Safety: We just wrote valid utf8 hex string into the dst
         return Ok(unsafe { mut_str(dst) });

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -110,7 +110,6 @@ pub fn hex_encode_custom<'a>(
         match crate::vectorization_support() {
             crate::Vectorization::Neon => unsafe { hex_encode_neon(src, dst, upper_case) },
             crate::Vectorization::None => hex_encode_custom_case_fallback(src, dst, upper_case),
-            _ => unreachable!(),
         }
         // Safety: We just wrote valid utf8 hex string into the dst
         return Ok(unsafe { mut_str(dst) });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,7 @@ pub(crate) fn vectorization_support() -> Vectorization {
         return val;
     }
 
-    #[cfg(all(
-        target_arch = "aarch64",
-        target_feature = "neon"
-    ))]
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     {
         // reuse flag code from x86 impl
         use core::sync::atomic::{AtomicU8, Ordering};
@@ -88,7 +85,7 @@ pub(crate) fn vectorization_support() -> Vectorization {
                 0 => Vectorization::None,
                 3 => Vectorization::Neon,
                 _ => unreachable!(),
-            }
+            };
         }
 
         let val = vectorization_support_no_cache_arm();
@@ -200,8 +197,7 @@ mod tests {
         match vector_support {
             Vectorization::Neon => assert!(std::arch::is_aarch64_feature_detected!("neon")),
             Vectorization::None => assert!(
-                !cfg!(target_feature = "neon")
-                    || !std::arch::is_aarch64_feature_detected!("neon")
+                !cfg!(target_feature = "neon") || !std::arch::is_aarch64_feature_detected!("neon")
             ),
             _ => unreachable!(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ pub use crate::encode::hex_to;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub use crate::decode::{hex_check_sse, hex_check_sse_with_case};
 
+#[cfg(target_arch = "aarch64")]
+pub use crate::decode::{hex_check_neon, hex_check_neon_with_case};
+
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[allow(dead_code)]
 pub(crate) enum Vectorization {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ pub use crate::decode::{hex_check_sse, hex_check_sse_with_case};
 pub use crate::decode::{hex_check_neon, hex_check_neon_with_case};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-#[allow(dead_code)]
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub(crate) enum Vectorization {
     None = 0,
@@ -191,7 +190,6 @@ mod tests {
                     !cfg!(target_feature = "sse")
                         || !is_x86_feature_detected!("avx2") && !is_x86_feature_detected!("sse4.1")
                 ),
-                _ => unreachable!(),
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,11 +156,14 @@ unsafe fn avx2_support_no_cache_x86() -> bool {
 #[cfg(target_arch = "aarch64")]
 #[cold]
 fn vectorization_support_no_cache_arm() -> Vectorization {
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(feature = "std")]
     if std::arch::is_aarch64_feature_detected!("neon") {
         return Vectorization::Neon;
     }
+    #[cfg(target_feature = "neon")]
+    return Vectorization::Neon;
 
+    #[allow(unreachable_code)]
     Vectorization::None
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub(crate) enum Vectorization {
     None = 0,
     SSE41 = 1,
     AVX2 = 2,
+    #[cfg(target_arch = "aarch64")]
     Neon = 3,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,9 @@ pub use crate::decode::{hex_check_neon, hex_check_neon_with_case};
 #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub(crate) enum Vectorization {
     None = 0,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     SSE41 = 1,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     AVX2 = 2,
     #[cfg(target_arch = "aarch64")]
     Neon = 3,
@@ -199,7 +201,6 @@ mod tests {
             Vectorization::None => assert!(
                 !cfg!(target_feature = "neon") || !std::arch::is_aarch64_feature_detected!("neon")
             ),
-            _ => unreachable!(),
         }
 
         #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]


### PR DESCRIPTION
Add implementations for [`hex_encode`](https://github.com/Lynnesbian/faster-hex/blob/859221bbcfd2256047b5bf6d334f30beb906ee3f/src/encode.rs#L234) and [`hex_check`](https://github.com/Lynnesbian/faster-hex/blob/859221bbcfd2256047b5bf6d334f30beb906ee3f/src/decode.rs#L226) using ARM's [NEON](https://developer.arm.com/Architectures/Neon) (*aka AdvSIMD*) SIMD instruction set. These implementations are based on the existing SSE4.2 ones - they're more or less direct translations.

These implementations are only active on `aarch64` targets and not 32-bit ARM targets (`armv7` etc), because [NEON intrinsics on 32-bit ARM are unstable](https://github.com/rust-lang/rust/issues/111800).

---

Unfortunately, checking for NEON support at runtime is a difficult problem to solve. My current implementation is less than ideal:

https://github.com/Lynnesbian/faster-hex/blob/859221bbcfd2256047b5bf6d334f30beb906ee3f/src/lib.rs#L159-L171

I've found a variety of differing ways to get this information on Aarch64 platforms:
- Linux: The `HWCAP` interface ([`getauxval()`](https://man7.org/linux/man-pages/man3/getauxval.3.html)), or reading `/proc/cpuinfo`
- Android: Google's [cpu_features](https://github.com/google/cpu_features) library 
- Windows: Call [`IsProcessorFeaturePresent`](https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/System/Threading/fn.IsProcessorFeaturePresent.html) with [`PF_ARM_NEON_INSTRUCTIONS_AVAILABLE`](https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/System/Threading/constant.PF_ARM_NEON_INSTRUCTIONS_AVAILABLE.html)
- BSDs:
  - FreeBSD: [`elf_aux_info()`](https://man.freebsd.org/cgi/man.cgi?elf_aux_info(3))
  - NetBSD: `sysctlbyname` with `machdep.neon_present`
  - OpenBSD: [`sysctl`](https://man.openbsd.org/man2/sysctl.2) with `CTL_MACHDEP` and [`CPU_ID_AA64PFR0`](https://github.com/openbsd/src/blob/208893442c38e0767db1293632337acc2532616c/sys/arch/arm64/include/cpu.h#L35)
  - It's worth noting that `/proc/cpuinfo`, if enabled by the given BSD, will also work

There's no nice, cross-platform, no-`std` method to do this, like there is with x86's `cpuid`. And worse - many of these methods *only* work for Aarch64, and not 32-bit ARM platforms.

I decided against including all of these methods in the `vectorization_support` function. They'd necessitate bringing in multiple new dependencies, and would make testing much more complicated.