### PR TITLE
Fix rust audit check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ harness = false
 [[bench]]
 name = "check"
 harness = false
+


### PR DESCRIPTION
This PR want to find out and fix the cargo audit check error:
![image](https://github.com/user-attachments/assets/a2fe986b-9ea7-47cc-8729-98a9f255b2d2)
