### PR TITLE
cargo: set MSRV to 1.61.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,14 @@ name = "faster-hex"
 version = "0.10.0"
 authors = ["zhangsoledad <787953403@qq.com>"]
 edition = "2018"
+rust-version = "1.61.0"
 keywords = ["simd", "hex", "no-std"]
 license = "MIT"
 description = "Fast hex encoding."
 repository = "https://github.com/NervosFoundation/faster-hex"
 homepage = "https://github.com/NervosFoundation/faster-hex"
 readme = "README.md"
-exclude = [
-    "afl/*",
-    "benches/*",
-    "fuzz/*",
-    "CHANGELOG.md"
-]
+exclude = ["afl/*", "benches/*", "fuzz/*", "CHANGELOG.md"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
@@ -38,9 +34,9 @@ criterion = "0.5"
 rustc-hex = "1.0"
 hex = "0.3.2"
 proptest = "1.0"
-serde = { version = "1.0", features = ["derive"]}
-bytes = {version = "1.4.0"}
-serde_json ={ version = "1.0"}
+serde = { version = "1.0", features = ["derive"] }
+bytes = { version = "1.4.0" }
+serde_json = { version = "1.0" }
 
 [[bench]]
 name = "hex"


### PR DESCRIPTION
I confirmed faster-hex's MSRV is 1.61.0

```bash
❯ rm Cargo.lock; rustup run 1.60.0 cargo check
rm: cannot remove 'Cargo.lock': No such file or directory
warning: Found `feature = ...` in `target.'cfg(...)'.dependencies`. This key is not supported for selecting dependencies and will not work as expected. Use the [features] section instead: https://doc.rust-lang.org/cargo/reference/features.html
warning: unused manifest key: target.cfg(not(feature = "alloc")).features
    Updating crates.io index
error: package `serde_derive v1.0.219` cannot be built because it requires rustc 1.61 or newer, while the currently active rustc version is 1.60.0


exec in 🌐 Matrix in faster-hex on  master is 📦 v0.10.0 via 🦀 v1.87.0-nightly took 2s
❯ rm Cargo.lock; rustup run 1.61.0 cargo check
warning: Found `feature = ...` in `target.'cfg(...)'.dependencies`. This key is not supported for selecting dependencies and will not work as expected. Use the [features] section instead: https://doc.rust-lang.org/cargo/reference/features.html
warning: unused manifest key: target.cfg(not(feature = "alloc")).features
    Updating crates.io index
    Checking byteorder v1.5.0
    Checking stable_deref_trait v1.2.0
   Compiling heapless v0.8.0
   Compiling serde v1.0.219
    Checking hash32 v0.3.1
    Checking faster-hex v0.10.0 (/home/exec/Projects/github.com/nervosnetwork/faster-hex)
    Finished dev [unoptimized + debuginfo] target(s) in 1.59s

```