### PR TITLE
fix: don't pull heapless into std builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+### Bug Fixes
+
+* Don't pull `heapless` into `std`/`alloc` builds: `[target.'cfg(not(feature = "alloc"))']` predicates are not supported by Cargo and match unconditionally, so `heapless` was compiled into every build while only no-`alloc` code used it ([#65](https://github.com/nervosnetwork/faster-hex/issues/65)). It is now an optional dependency behind the new additive `heapless` feature. **BREAKING**: in builds without `alloc`, `hex_string`/`hex_string_upper` are replaced by `hex_string_heapless`/`hex_string_upper_heapless`, gated behind that feature; `alloc` and `std` users are unaffected.
+
+# [0.10.0](https://github.com/nervosnetwork/faster-hex/compare/v0.9.0...a7ce51feb378bc713f7e39f2f3c3172372abc4ec) (2024-09-14)
+
 ### Features
 
 * Add PartialEq derived macro to Error in order to be able to test error cases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["afl/*", "benches/*", "fuzz/*", "CHANGELOG.md"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
+heapless = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 
 [features]
@@ -21,13 +22,8 @@ default = ["std", "serde"]
 std = ["alloc", "serde?/std"]
 alloc = ["defmt?/alloc"]
 serde = ["dep:serde", "alloc"]
-defmt-03 = ["dep:defmt"]
-
-[target.'cfg(not(feature = "alloc"))'.dependencies]
-heapless = { version = "0.8" }
-
-[target.'cfg(not(feature = "alloc"))'.features]
-defmt-03 = ["dep:defmt", "heapless/defmt-03"]
+defmt-03 = ["dep:defmt", "heapless?/defmt-03"]
+heapless = ["dep:heapless"]
 
 [dev-dependencies]
 criterion = "0.5"
@@ -41,11 +37,13 @@ serde_json = { version = "1.0" }
 [[bench]]
 name = "hex"
 harness = false
+required-features = ["std"]
 
 
 [[bench]]
 name = "check"
 harness = false
+required-features = ["std"]
 
 [lints.clippy]
 undocumented_unsafe_blocks = "warn"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ struct Simple {
 ```
 
 
+heapless feature (`no-std` without `alloc`)
+```rust
+let hex: heapless::String<24> = faster_hex::hex_string_heapless(b"Hello world!");
+```
+
 ## Notice
 
 Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -382,17 +382,19 @@ pub fn hex_decode_fallback(src: &[u8], dst: &mut [u8]) {
 #[cfg(test)]
 mod tests {
     use crate::decode::NIL;
-    use crate::{
-        decode::{
-            hex_check_fallback, hex_check_fallback_with_case, hex_decode_fallback, CheckCase,
-        },
-        encode::hex_string,
+    use crate::decode::{
+        hex_check_fallback, hex_check_fallback_with_case, hex_decode_fallback, CheckCase,
     };
+    #[cfg(feature = "alloc")]
+    use crate::encode::hex_string;
+    #[cfg(all(feature = "heapless", not(feature = "alloc")))]
+    use crate::encode::hex_string_heapless;
     use proptest::proptest;
 
-    #[cfg(not(feature = "alloc"))]
+    #[cfg(all(feature = "heapless", not(feature = "alloc")))]
     const CAPACITY: usize = 128;
 
+    #[cfg(any(feature = "alloc", feature = "heapless"))]
     fn _test_decode_fallback(s: &String) {
         let len = s.as_bytes().len();
         let mut dst = Vec::with_capacity(len);
@@ -400,8 +402,8 @@ mod tests {
 
         #[cfg(feature = "alloc")]
         let hex_string = hex_string(s.as_bytes());
-        #[cfg(not(feature = "alloc"))]
-        let hex_string = hex_string::<CAPACITY>(s.as_bytes());
+        #[cfg(all(feature = "heapless", not(feature = "alloc")))]
+        let hex_string = hex_string_heapless::<CAPACITY>(s.as_bytes());
 
         hex_decode_fallback(hex_string.as_bytes(), &mut dst);
 
@@ -416,7 +418,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "alloc"))]
+    #[cfg(all(feature = "heapless", not(feature = "alloc")))]
     proptest! {
         #[test]
         fn test_decode_fallback(ref s in ".{1,16}") {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -9,9 +9,6 @@ use core::arch::aarch64::*;
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec};
 
-#[cfg(not(feature = "alloc"))]
-use heapless::{String, Vec};
-
 use crate::error::Error;
 
 static TABLE_LOWER: &[u8] = b"0123456789abcdef";
@@ -34,9 +31,12 @@ fn hex_string_custom_case(src: &[u8], upper_case: bool) -> String {
     }
 }
 
-#[cfg(not(feature = "alloc"))]
-fn hex_string_custom_case<const N: usize>(src: &[u8], upper_case: bool) -> String<N> {
-    let mut buffer = Vec::<_, N>::new();
+#[cfg(feature = "heapless")]
+fn hex_string_heapless_custom_case<const N: usize>(
+    src: &[u8],
+    upper_case: bool,
+) -> heapless::String<N> {
+    let mut buffer = heapless::Vec::<u8, N>::new();
     buffer
         .resize(src.len() * 2, 0)
         .expect("String<N> capacity too short");
@@ -47,10 +47,10 @@ fn hex_string_custom_case<const N: usize>(src: &[u8], upper_case: bool) -> Strin
     }
 
     if cfg!(debug_assertions) {
-        String::from_utf8(buffer).unwrap()
+        heapless::String::from_utf8(buffer).unwrap()
     } else {
         // Safety: We just wrote valid utf8 hex string into the dst
-        unsafe { String::from_utf8_unchecked(buffer) }
+        unsafe { heapless::String::from_utf8_unchecked(buffer) }
     }
 }
 
@@ -59,19 +59,29 @@ pub fn hex_string(src: &[u8]) -> String {
     hex_string_custom_case(src, false)
 }
 
-#[cfg(not(feature = "alloc"))]
-pub fn hex_string<const N: usize>(src: &[u8]) -> String<N> {
-    hex_string_custom_case(src, false)
-}
-
 #[cfg(feature = "alloc")]
 pub fn hex_string_upper(src: &[u8]) -> String {
     hex_string_custom_case(src, true)
 }
 
-#[cfg(not(feature = "alloc"))]
-pub fn hex_string_upper<const N: usize>(src: &[u8]) -> String<N> {
-    hex_string_custom_case(src, true)
+/// Hex encode src into a fixed-capacity [`heapless::String`], lower case.
+///
+/// # Panics
+///
+/// Panics if the capacity `N` is less than `src.len() * 2`.
+#[cfg(feature = "heapless")]
+pub fn hex_string_heapless<const N: usize>(src: &[u8]) -> heapless::String<N> {
+    hex_string_heapless_custom_case(src, false)
+}
+
+/// Hex encode src into a fixed-capacity [`heapless::String`], upper case.
+///
+/// # Panics
+///
+/// Panics if the capacity `N` is less than `src.len() * 2`.
+#[cfg(feature = "heapless")]
+pub fn hex_string_upper_heapless<const N: usize>(src: &[u8]) -> heapless::String<N> {
+    hex_string_heapless_custom_case(src, true)
 }
 
 pub fn hex_encode_custom<'a>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,14 @@ pub use crate::decode::{
     hex_decode_unchecked,
 };
 pub use crate::encode::{
-    hex_encode, hex_encode_fallback, hex_encode_upper, hex_encode_upper_fallback, hex_string,
-    hex_string_upper,
+    hex_encode, hex_encode_fallback, hex_encode_upper, hex_encode_upper_fallback,
 };
+
+#[cfg(feature = "alloc")]
+pub use crate::encode::{hex_string, hex_string_upper};
+
+#[cfg(feature = "heapless")]
+pub use crate::encode::{hex_string_heapless, hex_string_upper_heapless};
 
 pub use crate::error::Error;
 
@@ -175,11 +180,15 @@ fn vectorization_support_no_cache_arm() -> Vectorization {
 #[cfg(test)]
 mod tests {
     use crate::decode::{hex_decode, hex_decode_with_case, CheckCase};
-    use crate::encode::{hex_encode, hex_string};
-    use crate::{hex_encode_upper, hex_string_upper, vectorization_support, Vectorization};
+    use crate::encode::hex_encode;
+    #[cfg(feature = "alloc")]
+    use crate::encode::{hex_string, hex_string_upper};
+    #[cfg(all(feature = "heapless", not(feature = "alloc")))]
+    use crate::encode::{hex_string_heapless, hex_string_upper_heapless};
+    use crate::{hex_encode_upper, vectorization_support, Vectorization};
     use proptest::proptest;
 
-    #[cfg(not(feature = "alloc"))]
+    #[cfg(all(feature = "heapless", not(feature = "alloc")))]
     const CAPACITY: usize = 128;
 
     #[test]
@@ -209,6 +218,7 @@ mod tests {
         assert_eq!(vector_support, Vectorization::None);
     }
 
+    #[cfg(any(feature = "alloc", feature = "heapless"))]
     fn _test_hex_encode(s: &String) {
         let mut buffer = vec![0; s.as_bytes().len() * 2];
         {
@@ -216,8 +226,8 @@ mod tests {
 
             #[cfg(feature = "alloc")]
             let hex_string = hex_string(s.as_bytes());
-            #[cfg(not(feature = "alloc"))]
-            let hex_string = hex_string::<CAPACITY>(s.as_bytes());
+            #[cfg(all(feature = "heapless", not(feature = "alloc")))]
+            let hex_string = hex_string_heapless::<CAPACITY>(s.as_bytes());
 
             assert_eq!(encode, hex::encode(s));
             assert_eq!(hex_string.as_str(), hex::encode(s));
@@ -228,8 +238,8 @@ mod tests {
 
             #[cfg(feature = "alloc")]
             let hex_string_upper = hex_string_upper(s.as_bytes());
-            #[cfg(not(feature = "alloc"))]
-            let hex_string_upper = hex_string_upper::<CAPACITY>(s.as_bytes());
+            #[cfg(all(feature = "heapless", not(feature = "alloc")))]
+            let hex_string_upper = hex_string_upper_heapless::<CAPACITY>(s.as_bytes());
 
             assert_eq!(encode_upper, hex::encode_upper(s));
             assert_eq!(hex_string_upper.as_str(), hex::encode_upper(s));
@@ -244,7 +254,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "alloc"))]
+    #[cfg(all(feature = "heapless", not(feature = "alloc")))]
     proptest! {
         #[test]
         fn test_hex_encode(ref s in ".{0,16}") {
@@ -252,6 +262,7 @@ mod tests {
         }
     }
 
+    #[cfg(any(feature = "alloc", feature = "heapless"))]
     fn _test_hex_decode(s: &String) {
         let len = s.as_bytes().len();
         {
@@ -259,8 +270,8 @@ mod tests {
             dst.resize(len, 0);
             #[cfg(feature = "alloc")]
             let hex_string = hex_string(s.as_bytes());
-            #[cfg(not(feature = "alloc"))]
-            let hex_string = hex_string::<CAPACITY>(s.as_bytes());
+            #[cfg(all(feature = "heapless", not(feature = "alloc")))]
+            let hex_string = hex_string_heapless::<CAPACITY>(s.as_bytes());
 
             hex_decode(hex_string.as_bytes(), &mut dst).unwrap();
 
@@ -273,8 +284,8 @@ mod tests {
             dst.resize(len, 0);
             #[cfg(feature = "alloc")]
             let hex_string_upper = hex_string_upper(s.as_bytes());
-            #[cfg(not(feature = "alloc"))]
-            let hex_string_upper = hex_string_upper::<CAPACITY>(s.as_bytes());
+            #[cfg(all(feature = "heapless", not(feature = "alloc")))]
+            let hex_string_upper = hex_string_upper_heapless::<CAPACITY>(s.as_bytes());
 
             hex_decode_with_case(hex_string_upper.as_bytes(), &mut dst, CheckCase::Upper).unwrap();
 
@@ -290,12 +301,45 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "alloc"))]
+    #[cfg(all(feature = "heapless", not(feature = "alloc")))]
     proptest! {
         #[test]
         fn test_hex_decode(ref s in ".{1,16}") {
             _test_hex_decode(s);
         }
+    }
+
+    #[cfg(feature = "heapless")]
+    #[test]
+    fn test_hex_string_heapless() {
+        let src = b"Hello world!";
+        let lower: heapless::String<24> = crate::hex_string_heapless(src);
+        assert_eq!(lower.as_str(), "48656c6c6f20776f726c6421");
+        let upper: heapless::String<24> = crate::hex_string_upper_heapless(src);
+        assert_eq!(upper.as_str(), "48656C6C6F20776F726C6421");
+    }
+
+    #[cfg(feature = "heapless")]
+    #[test]
+    fn test_hex_string_heapless_empty_and_spare_capacity() {
+        let empty: heapless::String<0> = crate::hex_string_heapless(b"");
+        assert_eq!(empty.as_str(), "");
+        let spare: heapless::String<8> = crate::hex_string_heapless(b"ab");
+        assert_eq!(spare.as_str(), "6162");
+    }
+
+    #[cfg(feature = "heapless")]
+    #[test]
+    #[should_panic(expected = "capacity too short")]
+    fn test_hex_string_heapless_capacity_too_short() {
+        let _: heapless::String<4> = crate::hex_string_heapless(b"abc");
+    }
+
+    #[cfg(feature = "heapless")]
+    #[test]
+    #[should_panic(expected = "capacity too short")]
+    fn test_hex_string_upper_heapless_capacity_too_short() {
+        let _: heapless::String<0> = crate::hex_string_upper_heapless(b"x");
     }
 
     fn _test_hex_decode_check(s: &String, ok: bool) {


### PR DESCRIPTION
Closes https://github.com/nervosnetwork/faster-hex/issues/65 - it nicely removes the `heapless` and `hash32` from my build.

It's a different take than https://github.com/nervosnetwork/faster-hex/pull/68 because it follows the cargo feature [guidelines](https://doc.rust-lang.org/cargo/reference/features.html), as in, the features should be additive. So, no mutually-exclusive features, no extra build file.

> A consequence of this is that features should be additive. That is, enabling a feature should not disable functionality, and it should usually be safe to enable any combination of features. A feature should not introduce a [SemVer-incompatible change](https://doc.rust-lang.org/cargo/reference/features.html#semver-compatibility).

This is a breaking change, though, but subjectively I believe it's more _correct_ design. This is a breaking for no-alloc users, though. It _should_ be fine because I followed the guidelines straight from the README. :)

> Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.

It should be fine to expose `_heapless` suffix here given it was kind of exposed anyway via the `heapless::String`.

I also took the liberty of fixing CHANGELOG - it had a missing `0.10.0` section. No tag so I had to use a commit from crates.io.

If it looks good, I'd appreciate a small release so that `std` users don't have to pull those extra deps.
